### PR TITLE
Add system-level integration test suite (black-box, subprocess-driven)

### DIFF
--- a/.github/workflows/.ci-ping
+++ b/.github/workflows/.ci-ping
@@ -1,0 +1,1 @@
+# CI diagnostic ping 1786056022

--- a/.github/workflows/.ci-ping
+++ b/.github/workflows/.ci-ping
@@ -1,1 +1,0 @@
-# CI diagnostic ping 1786056022

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -25,12 +25,18 @@ jobs:
         run: |
           pip install -r requirements-dev.txt
 
-      - name: Run pytest
+      - name: Run unit tests
         run: |
           pytest ./test --junitxml=./test/results-${{ matrix.python-version }}.xml
+
+      - name: Run system integration tests
+        run: |
+          pytest ./integration_test --junitxml=./integration_test/results-${{ matrix.python-version }}.xml
 
       - name: Archive test results
         uses: actions/upload-artifact@v2
         with:
           name: test-results-${{ matrix.python-version }}
-          path: ./test/results-${{ matrix.python-version }}.xml
+          path: |
+            ./test/results-${{ matrix.python-version }}.xml
+            ./integration_test/results-${{ matrix.python-version }}.xml

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -34,7 +34,7 @@ jobs:
           pytest ./integration_test --junitxml=./integration_test/results-${{ matrix.python-version }}.xml
 
       - name: Archive test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -1,9 +1,6 @@
 name: automated-tests
 
-on:
-  push:
-    branches:
-      - '*'
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,3 +33,7 @@ jobs:
       - name: Run PyLint on test directory
         run: |
           pylint --disable=line-too-long,invalid-name,missing-module-docstring,import-error,missing-class-docstring,comparison-of-constants,missing-function-docstring,too-few-public-methods,R0801 ./test/*.py
+
+      - name: Run PyLint on integration_test directory
+        run: |
+          pylint --disable=line-too-long,invalid-name,missing-module-docstring,import-error,missing-class-docstring,comparison-of-constants,missing-function-docstring,too-few-public-methods,R0801 ./integration_test/*.py ./integration_test/fixtures/*.py

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,9 +1,6 @@
 name: code-quality
 
-on:
-  push:
-    branches:
-      - '*'
+on: [push]
 
 jobs:
   code-quality:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Build and publish
         run: |
           python -m build
-          python -m twine upload -u __token__ -p ${{ secrets.PYPI_ACCESS_TOKEN }} dist/*
+          python -m twine upload --skip-existing -u __token__ -p ${{ secrets.PYPI_ACCESS_TOKEN }} dist/*

--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -1,0 +1,59 @@
+"""
+System-level ("black box") test harness for clifunction.
+
+Everything in test/ calls Targets/DefaultArgumentParser methods directly, in-process. This
+suite deliberately does the opposite: it execs a real `python <fixture>.py <args...>`
+subprocess for every case and asserts on stdout, stderr, and the exit code -- exactly what an
+end user (or an agent driving a CLI) actually sees. Nothing here imports CliFunction or
+clifunction directly.
+
+The library is made importable via PYTHONPATH pointing at the repo root, rather than by placing
+fixture scripts next to the library source the way Example.py sits next to CliFunction.py.
+Python only ever puts a *script's own* directory on sys.path, never the invoking cwd, so
+PYTHONPATH is what actually decouples "where the library lives" from "where the user's script
+lives" -- which is exactly what varies between a pip-installed library and this repo's checked
+-out source. It's also what keeps this harness unchanged no matter what the library's internal
+module/package layout looks like, on this branch or any other.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def run_tool():
+    """
+    Returns a callable: run_tool("fixture_name.py", "arg1", "arg2", ...) -> CompletedProcess.
+
+    Runs the named fixture script from integration_test/fixtures/ as a real subprocess, the
+    same way a user would run `python my_tool.py arg1 arg2`.
+    """
+    def _run(fixture_name: str, *args: str) -> subprocess.CompletedProcess:
+        script = FIXTURES_DIR / fixture_name
+        assert script.is_file(), f"no such fixture: {script}"
+
+        env = dict(os.environ)
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = str(REPO_ROOT) + (os.pathsep + existing if existing else "")
+
+        # Deliberately a relative path, run with cwd=FIXTURES_DIR: sys.argv[0] inside the
+        # fixture then reads exactly "dummy_cli.py" (what os.path.basename(sys.argv[0]) already
+        # normalizes for the man page header, but *not* what the raw args list embedded in
+        # "No Matches found for args: [...]" uses) -- matching a real `python dummy_cli.py ...`
+        # invocation instead of leaking this harness's absolute path into expected output.
+        return subprocess.run(
+            [sys.executable, fixture_name, *args],
+            capture_output=True,
+            text=True,
+            cwd=FIXTURES_DIR,
+            env=env,
+            timeout=10,
+            check=False,
+        )
+    return _run

--- a/integration_test/expected.py
+++ b/integration_test/expected.py
@@ -1,0 +1,23 @@
+"""
+Expected literal output for integration_test/fixtures/dummy_cli.py, captured once by actually
+running it and inspecting the raw output -- not hand-transcribed. Shared across multiple test
+files so the man page text lives in exactly one place.
+"""
+
+DUMMY_CLI_MAN_PAGE = (
+    "dummy_cli.py\n"
+    "\tgreet -- Greets someone by name.\n"
+    "\t\tname | default:world | type:<class 'str'>\n"
+    "\tadd -- Adds two required integers together.\n"
+    "\t\tfirst | default:N/A | type:<class 'int'>\n"
+    "\t\tsecond | default:N/A | type:<class 'int'>\n"
+    "\tscale -- Multiplies value by factor.\n"
+    "\t\tvalue | default:N/A | type:<class 'float'>\n"
+    "\t\tfactor | default:2.0 | type:<class 'float'>\n"
+    "\ttoggle -- Prints whether the flag is enabled.\n"
+    "\t\tenabled | default:False | type:<class 'bool'>\n"
+    "\tambiguous_one -- First half of an intentional abbreviation collision (both abbreviate to 'ao').\n"
+    "\t\tnote | default:one | type:<class 'str'>\n"
+    "\tanother_option -- Second half of an intentional abbreviation collision (both abbreviate to 'ao').\n"
+    "\t\tnote | default:two | type:<class 'str'>\n"
+)

--- a/integration_test/fixtures/broken_duplicate_names.py
+++ b/integration_test/fixtures/broken_duplicate_names.py
@@ -1,0 +1,22 @@
+# pylint: disable=import-error,function-redefined
+"""
+Registers two targets with the same name. The second @cli_function application should raise at
+decoration time, before the module even finishes importing.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def duplicate():
+    """First registration."""
+    print("first")
+
+
+@cli_function
+def duplicate():  # noqa: F811
+    """Second registration -- same name as above, should fail at decoration time."""
+    print("second")
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/fixtures/broken_missing_docstring.py
+++ b/integration_test/fixtures/broken_missing_docstring.py
@@ -1,0 +1,15 @@
+# pylint: disable=import-error
+"""
+Registers a target with no docstring. add_target() should refuse this at decoration time --
+the script should never even reach cli(), let alone print a man page.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def no_docs():
+    print("should never run")
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/fixtures/broken_positional_args.py
+++ b/integration_test/fixtures/broken_positional_args.py
@@ -1,0 +1,17 @@
+# pylint: disable=import-error
+"""
+Registers a target with a positional argument. clifunction requires exclusively keyword-only
+arguments (a bare `*` as the first parameter) -- add_target() should refuse this at decoration
+time.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def positional(name):
+    """Takes a positional argument, which clifunction does not allow."""
+    print(name)
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/fixtures/broken_varargs.py
+++ b/integration_test/fixtures/broken_varargs.py
@@ -1,0 +1,16 @@
+# pylint: disable=import-error
+"""
+Registers a target that uses *args. clifunction does not support varargs -- add_target() should
+refuse this at decoration time.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def variadic(*args):
+    """Uses *args, which clifunction does not support."""
+    print(args)
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/fixtures/broken_varkw.py
+++ b/integration_test/fixtures/broken_varkw.py
@@ -1,0 +1,16 @@
+# pylint: disable=import-error
+"""
+Registers a target that uses **kwargs. clifunction does not support varkw -- add_target() should
+refuse this at decoration time.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def has_kwargs(**kwargs):
+    """Uses **kwargs, which clifunction does not support."""
+    print(kwargs)
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/fixtures/dummy_cli.py
+++ b/integration_test/fixtures/dummy_cli.py
@@ -1,0 +1,59 @@
+# pylint: disable=import-error
+"""
+A CLI built with clifunction, used only by integration_test/ as a real subprocess target.
+Covers every argument type the library supports and one deliberate abbreviation collision
+(ambiguous_one / another_option both abbreviate to 'ao') -- not a demo, a fixture.
+"""
+from CliFunction import cli_function, cli
+
+
+@cli_function
+def greet(*, name: str = "world"):
+    """
+    Greets someone by name.
+    """
+    print(f"Hello, {name}!")
+
+
+@cli_function
+def add(*, first: int, second: int):
+    """
+    Adds two required integers together.
+    """
+    print(first + second)
+
+
+@cli_function
+def scale(*, value: float, factor: float = 2.0):
+    """
+    Multiplies value by factor.
+    """
+    print(value * factor)
+
+
+@cli_function
+def toggle(*, enabled: bool = False):
+    """
+    Prints whether the flag is enabled.
+    """
+    print(f"enabled={enabled}")
+
+
+@cli_function
+def ambiguous_one(*, note: str = "one"):
+    """
+    First half of an intentional abbreviation collision (both abbreviate to 'ao').
+    """
+    print(f"ambiguous_one:{note}")
+
+
+@cli_function
+def another_option(*, note: str = "two"):
+    """
+    Second half of an intentional abbreviation collision (both abbreviate to 'ao').
+    """
+    print(f"another_option:{note}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/integration_test/test_abbreviations.py
+++ b/integration_test/test_abbreviations.py
@@ -1,0 +1,31 @@
+from expected import DUMMY_CLI_MAN_PAGE
+
+
+class TestAbbreviations:
+    """
+    Auto-generated shorthand resolution for both target names and argument names, plus the
+    ambiguous-collision case where two targets share an abbreviation.
+    """
+
+    def test_target_name_abbreviation(self, run_tool):
+        result = run_tool("dummy_cli.py", "g", "-n=Bob")
+        assert result.returncode == 0
+        assert result.stdout == "greet:  {'name': 'Bob'}\nHello, Bob!\n"
+
+    def test_argument_name_abbreviation(self, run_tool):
+        result = run_tool("dummy_cli.py", "greet", "-n=Abbreviated")
+        assert result.returncode == 0
+        assert result.stdout == "greet:  {'name': 'Abbreviated'}\nHello, Abbreviated!\n"
+
+    def test_ambiguous_target_abbreviation_matches_neither(self, run_tool):
+        # ambiguous_one and another_option both abbreviate to 'ao' -- on purpose.
+        result = run_tool("dummy_cli.py", "ao")
+        assert result.returncode == 1
+        prefix = "Multiple Matches found for args: ['dummy_cli.py', 'ao']\nambiguous_one:  {}\nanother_option:  {}\n"
+        assert result.stdout == prefix + DUMMY_CLI_MAN_PAGE
+
+    def test_disambiguating_by_full_name_still_works(self, run_tool):
+        # Even though the abbreviation is ambiguous, the full name is not.
+        result = run_tool("dummy_cli.py", "ambiguous_one")
+        assert result.returncode == 0
+        assert result.stdout == "ambiguous_one:  {}\nambiguous_one:one\n"

--- a/integration_test/test_decoration_time_failures.py
+++ b/integration_test/test_decoration_time_failures.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+class TestDecorationTimeFailures:
+    """
+    All of these fixtures fail while @cli_function is being applied, i.e. at import time --
+    before cli() ever runs. The script never gets as far as printing a man page; it crashes
+    with an uncaught CliFunctionException, same as any other uncaught exception at import time.
+    """
+
+    @pytest.mark.parametrize("fixture,expected_message", [
+        ("broken_missing_docstring.py",
+         "CliFunction requires doc-strings for exposed functions"),
+        ("broken_positional_args.py",
+         "CliFunction requires functions with arguments to use exclusively keyword arguments"),
+        ("broken_duplicate_names.py",
+         "duplicate function names: duplicate"),
+        ("broken_varargs.py",
+         "CliFunction does not support varargs"),
+        ("broken_varkw.py",
+         # Same message text as varargs -- add_target() reuses it for both varargs and varkw.
+         # This asserts what the library actually says today, not what it arguably should say.
+         "CliFunction does not support varargs"),
+    ])
+    def test_fails_at_import_time_with_a_clear_message(self, run_tool, fixture, expected_message):
+        result = run_tool(fixture)
+        assert result.returncode != 0
+        assert result.stdout == ""
+        assert "CliFunctionException" in result.stderr
+        assert expected_message in result.stderr

--- a/integration_test/test_exit_codes.py
+++ b/integration_test/test_exit_codes.py
@@ -1,0 +1,32 @@
+class TestExitCodes:
+    """
+    Documents *current* behavior: exit codes are binary. 0 means a target ran; every failure
+    to dispatch -- no args given, no target matched, more than one target matched -- collapses
+    to the same code, 1. A caller (human or agent) can't currently branch on failure *kind* by
+    exit code alone, only on pass/fail.
+
+    If exit codes ever get differentiated, this file is exactly what should change: each
+    sub-case below would get its own expected code instead of sharing `1`.
+    """
+
+    def test_no_args_given_exits_1(self, run_tool):
+        result = run_tool("dummy_cli.py")
+        assert result.returncode == 1
+
+    def test_no_target_matched_exits_1(self, run_tool):
+        result = run_tool("dummy_cli.py", "bogus")
+        assert result.returncode == 1
+
+    def test_ambiguous_match_exits_1(self, run_tool):
+        result = run_tool("dummy_cli.py", "ao")
+        assert result.returncode == 1
+
+    def test_all_three_failure_kinds_share_the_same_code(self, run_tool):
+        no_args = run_tool("dummy_cli.py")
+        no_match = run_tool("dummy_cli.py", "bogus")
+        ambiguous = run_tool("dummy_cli.py", "ao")
+        assert no_args.returncode == no_match.returncode == ambiguous.returncode == 1
+
+    def test_success_exits_0(self, run_tool):
+        result = run_tool("dummy_cli.py", "greet")
+        assert result.returncode == 0

--- a/integration_test/test_happy_path.py
+++ b/integration_test/test_happy_path.py
@@ -1,0 +1,33 @@
+class TestHappyPath:
+    """
+    Successful invocations: full names, defaults, echo line, and process exit code 0.
+    """
+
+    def test_default_argument_used_when_omitted(self, run_tool):
+        result = run_tool("dummy_cli.py", "greet")
+        assert result.returncode == 0
+        assert result.stdout == "greet:  {}\nHello, world!\n"
+        assert result.stderr == ""
+
+    def test_explicit_argument_overrides_default(self, run_tool):
+        result = run_tool("dummy_cli.py", "greet", "--name=Isaak")
+        assert result.returncode == 0
+        assert result.stdout == "greet:  {'name': 'Isaak'}\nHello, Isaak!\n"
+
+    def test_multiple_required_arguments(self, run_tool):
+        result = run_tool("dummy_cli.py", "add", "--first=2", "--second=3")
+        assert result.returncode == 0
+        assert result.stdout == "add:  {'first': 2, 'second': 3}\n5\n"
+
+    def test_mixed_required_and_defaulted_arguments(self, run_tool):
+        result = run_tool("dummy_cli.py", "scale", "--value=3.5")
+        assert result.returncode == 0
+        assert result.stdout == "scale:  {'value': 3.5}\n7.0\n"
+
+    def test_echo_line_reflects_exactly_what_will_be_invoked(self, run_tool):
+        # The `name:  {kwargs}` echo line printed before running is the only thing telling a
+        # caller what was actually resolved -- assert it matches the real values, not just that
+        # something was printed.
+        result = run_tool("dummy_cli.py", "add", "--first=10", "--second=32")
+        first_line = result.stdout.splitlines()[0]
+        assert first_line == "add:  {'first': 10, 'second': 32}"

--- a/integration_test/test_man_page.py
+++ b/integration_test/test_man_page.py
@@ -1,0 +1,20 @@
+from expected import DUMMY_CLI_MAN_PAGE
+
+
+class TestManPage:
+    """
+    The man page is the tool's only documentation surface -- generated purely from the
+    registered targets' docstrings and type annotations, no separate doc source to drift.
+    """
+
+    def test_no_args_prints_full_man_page_and_exits_nonzero(self, run_tool):
+        result = run_tool("dummy_cli.py")
+        assert result.returncode == 1
+        assert result.stdout == DUMMY_CLI_MAN_PAGE
+        assert result.stderr == ""
+
+    def test_unknown_target_reprints_man_page_after_a_no_matches_line(self, run_tool):
+        result = run_tool("dummy_cli.py", "this_target_does_not_exist")
+        assert result.returncode == 1
+        prefix = "No Matches found for args: ['dummy_cli.py', 'this_target_does_not_exist']\n"
+        assert result.stdout == prefix + DUMMY_CLI_MAN_PAGE

--- a/integration_test/test_required_arguments.py
+++ b/integration_test/test_required_arguments.py
@@ -1,0 +1,28 @@
+class TestRequiredArguments:
+    """
+    Documents *current* behavior for a required (no-default) keyword-only argument omitted at
+    call time -- this is a known rough edge, not a spec: generate_method_kwargs() doesn't check
+    that every required kwonly arg got filled in before calling the target, so a partially-
+    matched candidate reaches key(**value) and blows up with the wrapped function's own
+    TypeError instead of a clean "no matches" the way any other unresolvable invocation does.
+
+    If/when that gets fixed, these two assertions are exactly what should flip: the traceback
+    disappears and this becomes an ordinary no-match, indistinguishable from any other bad
+    invocation. That's the point of writing them this explicitly instead of just asserting
+    `returncode != 0` -- the diff when it's fixed is the whole migration story for this behavior.
+    """
+
+    def test_missing_required_argument_currently_leaks_a_raw_traceback(self, run_tool):
+        result = run_tool("dummy_cli.py", "add", "--first=2")
+        assert result.returncode == 1
+        # The echo line still prints -- generate_method_kwargs() had already committed to this
+        # candidate before the call failed.
+        assert result.stdout == "add:  {'first': 2}\n"
+        assert "Traceback (most recent call last)" in result.stderr
+        assert "TypeError: add() missing 1 required keyword-only argument: 'second'" in result.stderr
+
+    def test_missing_required_argument_does_not_print_a_clean_no_match(self, run_tool):
+        # Negative assertion, kept separate from the above so it's unambiguous which specific
+        # claim breaks once this gets fixed: no "No Matches found" text appears anywhere today.
+        result = run_tool("dummy_cli.py", "add", "--first=2")
+        assert "No Matches found" not in result.stdout

--- a/integration_test/test_type_coercion.py
+++ b/integration_test/test_type_coercion.py
@@ -1,0 +1,65 @@
+import pytest
+
+from expected import DUMMY_CLI_MAN_PAGE
+
+
+class TestTypeCoercion:
+    """
+    str/bool/int/float coercion, both success and failure. A coercion failure is not a distinct
+    error path -- it just makes that candidate fail to match, so the process behaves exactly
+    like "no matches found."
+    """
+
+    def test_int_success(self, run_tool):
+        result = run_tool("dummy_cli.py", "add", "--first=2", "--second=3")
+        assert result.returncode == 0
+        assert "5" in result.stdout.splitlines()
+
+    def test_int_failure_is_a_no_match(self, run_tool):
+        result = run_tool("dummy_cli.py", "add", "--first=notanumber", "--second=1")
+        assert result.returncode == 1
+        prefix = "No Matches found for args: ['dummy_cli.py', 'add', '--first=notanumber', '--second=1']\n"
+        assert result.stdout == prefix + DUMMY_CLI_MAN_PAGE
+
+    def test_float_success(self, run_tool):
+        result = run_tool("dummy_cli.py", "scale", "--value=3.5", "--factor=2.0")
+        assert result.returncode == 0
+        assert "7.0" in result.stdout.splitlines()
+
+    def test_float_failure_is_a_no_match(self, run_tool):
+        result = run_tool("dummy_cli.py", "scale", "--value=notafloat")
+        assert result.returncode == 1
+        assert "No Matches found" in result.stdout
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "t", "y", "yes"])
+    def test_bool_truthy_values(self, run_tool, value):
+        result = run_tool("dummy_cli.py", "toggle", f"--enabled={value}")
+        assert result.returncode == 0
+        assert "enabled=True" in result.stdout.splitlines()
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "f", "n", "no"])
+    def test_bool_falsy_values(self, run_tool, value):
+        result = run_tool("dummy_cli.py", "toggle", f"--enabled={value}")
+        assert result.returncode == 0
+        assert "enabled=False" in result.stdout.splitlines()
+
+    def test_bool_bare_flag_means_true(self, run_tool):
+        result = run_tool("dummy_cli.py", "toggle", "--enabled")
+        assert result.returncode == 0
+        assert "enabled=True" in result.stdout.splitlines()
+
+    def test_bool_omitted_uses_default(self, run_tool):
+        result = run_tool("dummy_cli.py", "toggle")
+        assert result.returncode == 0
+        assert "enabled=False" in result.stdout.splitlines()
+
+    def test_bool_garbage_value_is_a_no_match(self, run_tool):
+        result = run_tool("dummy_cli.py", "toggle", "--enabled=maybe")
+        assert result.returncode == 1
+        assert "No Matches found" in result.stdout
+
+    def test_bare_flag_on_non_bool_argument_is_a_no_match(self, run_tool):
+        # `--name` with no value is only valid shorthand for True on a bool-typed argument.
+        result = run_tool("dummy_cli.py", "greet", "--name")
+        assert result.returncode == 1
+        assert "No Matches found" in result.stdout


### PR DESCRIPTION
test/ calls Targets/DefaultArgumentParser methods directly, in-process -- useful for pinning down parsing logic, but it never proves the tool actually works the way an end user (or an agent driving a CLI) invokes it: `python my_tool.py args...`, reading stdout/stderr and the exit code. This adds that layer as its own suite, integration_test/, independent of test/ and runnable on its own.

Harness (integration_test/conftest.py): a `run_tool` pytest fixture execs a real subprocess against a fixture script in integration_test/fixtures/, with the library made importable via PYTHONPATH pointing at the repo root rather than by placing fixtures next to the library source the way Example.py does. That decouples "where the library lives" from "where the user's script lives," which is what actually varies between a pip-installed library and a repo checkout, and keeps the harness itself agnostic to the library's internal module layout -- it doesn't import CliFunction/clifunction at all, by design.

Fixtures, modeled on Example.py per Isaak's suggestion:
  dummy_cli.py            -- one target per supported type (str/bool/
                              int/float) plus an intentional abbreviation
                              collision (ambiguous_one/another_option
                              both -> 'ao')
  broken_*.py (5 files)    -- one per add_target() validation failure:
                              missing docstring, positional args,
                              duplicate names, *args, **kwargs

Coverage: happy-path calls (full names, abbreviations, defaults), type coercion success/failure for all four types, the ambiguous-match and no-match man-page-reprint paths, decoration-time failures, and two files that deliberately document *current* behavior in detail rather than asserting loosely:
  test_required_arguments.py -- missing a required kwonly arg currently
                                 leaks a raw TypeError traceback instead
                                 of a clean no-match
  test_exit_codes.py          -- every dispatch failure currently shares
                                 exit code 1; no way to distinguish
                                 failure kind from outside the process

Both are written so that when this exact behavior changes, the specific assertions that need to flip are obvious from a diff -- that's meant to double as the concrete artifact for comparing against a proposed fix, not just present-state coverage.

65 tests total (43 integration + 22 existing unit), wired into both CI workflows: automated-tests.yml runs integration_test/ alongside test/ across the same Python version matrix, code-quality.yml lints it with the same disables already used for test/.