### PR TITLE
Upgrade CI matrix to latest Python versions

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Adds Python 3.13 and 3.14 to `automated-tests.yml`'s test matrix (now `3.8`–`3.14`).
- Bumps `actions/checkout` (v2 → v7) and `actions/setup-python` (v2 → v7) to current releases -- v2 of setup-python predates 3.13/3.14 and can't be trusted to resolve those versions correctly.

Per endoflife.date, 3.10–3.14 are all currently maintained; 3.8 and 3.9 are already past end-of-life (3.9's window closed 2025-10-31). Kept both in the matrix anyway since `pyproject.toml` still declares `requires-python = ">=3.8"` -- dropping them from CI would leave that floor untested. Whether to raise the floor and drop them is a separate decision, not bundled in here.

Scoped to `automated-tests.yml` only ("the build") -- `code-quality.yml`/`deploy-pages.yml` still on old action versions, untouched.

## Test plan
- [ ] `pytest ./test ./integration_test` locally (Python 3.14.4) -- 65 passed, 2 skipped
- [ ] YAML validated
- [ ] CI itself is the real test here -- all 7 matrix legs + code-quality must go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)